### PR TITLE
Drop the dependency on drush, but add one on git.

### DIFF
--- a/drupal_audit.sh
+++ b/drupal_audit.sh
@@ -2,9 +2,15 @@
 #
 ### Script to determine the state of an audited Drupal website
 #
-### Prerequisites: Unix operating system, drush command tool
-### This script should be at Drupal's root directory
-#
+### Prerequisites: Unix operating system, Git
+### This script should be at Drupal's root directory#
+
+# Checkout Drush 5.x if needed.
+if [ ! -d drush ]; then
+  git clone git://git.drupal.org/project/drush --branch 7.x-5.x drush
+fi
+export PATH="$(pwd)/drush:$PATH"
+
 DRUPAL_VERSION = `drush status | grep 'Drupal version' | cut -d: -f2 | sed -e s/[^0-9]//`
 
 echo "Start Audit report" > drupal_audit_report.txt


### PR DESCRIPTION
This allow us to get drush on the fly if needed, plus having git support may be usefull for later operations.
